### PR TITLE
Fix mapp

### DIFF
--- a/CGRtools/algorithms/standardize.py
+++ b/CGRtools/algorithms/standardize.py
@@ -1360,11 +1360,11 @@ class StandardizeReaction:
         for bad, good in reactions:
             if str(bad) != str(good):
                 raise ValueError('bad and good reaction should be equal')
-
-            gc = (~good).augmented_substructure((~good).center_atoms, deep=1)
-            bc = (~bad).augmented_substructure((~bad).center_atoms, deep=1)
+            
             cgr_good, cgr_bad = ~good, ~bad
-
+            gc = (cgr_good).augmented_substructure((cgr_good).center_atoms, deep=1)
+            bc = (cgr_bad).augmented_substructure((cgr_bad).center_atoms, deep=1)
+            
             atoms = set(bc.atoms_numbers + gc.atoms_numbers)      
 
             pr_g, pr_b = set(), set()

--- a/CGRtools/algorithms/standardize.py
+++ b/CGRtools/algorithms/standardize.py
@@ -1362,8 +1362,8 @@ class StandardizeReaction:
                 raise ValueError('bad and good reaction should be equal')
             
             cgr_good, cgr_bad = ~good, ~bad
-            gc = (cgr_good).augmented_substructure([x for l in good.centers_list for x in l], deep=1)
-            bc = (cgr_bad).augmented_substructure([x for l in bad.centers_list for x in l], deep=1)
+            gc = cgr_good.augmented_substructure([x for l in good.centers_list for x in l], deep=1)
+            bc = cgr_bad.augmented_substructure([x for l in bad.centers_list for x in l], deep=1)
             
             atoms = set(bc.atoms_numbers + gc.atoms_numbers)      
 
@@ -1376,15 +1376,14 @@ class StandardizeReaction:
             strange_atoms = pr_b.difference(pr_g)
             atoms.update(strange_atoms)
 
-            bad_query = (cgr_bad).substructure(atoms.intersection(cgr_bad), as_query=True)
-            good_query = (cgr_good).substructure(atoms.intersection(cgr_good), as_query=True)
+            bad_query = cgr_bad.substructure(atoms.intersection(cgr_bad), as_query=True)
+            good_query = cgr_good.substructure(atoms.intersection(cgr_good), as_query=True)
 
             fix = {}
             rules = []
             for mb, mg in zip(bad.products, good.products):
-                fx = {k: v for k, v in zip(mb, mg) if k != v}
-                fx = {k:fx[k] for k in atoms.intersection(fx)}
-                fix.update(fx)
+                fix.update({k: v for k, v in zip(mb, mg) if k != v and k in atoms})
+
             valid = set(fix).difference(strange_atoms)
             rules.append((bad_query, good_query, fix, valid))
 

--- a/CGRtools/algorithms/standardize.py
+++ b/CGRtools/algorithms/standardize.py
@@ -1383,6 +1383,7 @@ class StandardizeReaction:
             rules = []
             for mb, mg in zip(bad.products, good.products):
                 fx = {k: v for k, v in zip(mb, mg) if k != v}
+                fx = {k:fx[k] for k in atoms.intersection(fx)}
                 fix.update(fx)
             valid = set(fix).difference(strange_atoms)
             rules.append((bad_query, good_query, fix, valid))

--- a/CGRtools/algorithms/standardize.py
+++ b/CGRtools/algorithms/standardize.py
@@ -1329,7 +1329,7 @@ class StandardizeReaction:
             for mapping in bad_query.get_mapping(cgr, automorphism_filter=False):
                 if not seen.isdisjoint(mapping.values()):  # prevent matching same RC
                     continue
-                mapping = {key : value for key, value in fix.items()}
+                mapping = {mapping[n]: mapping[m] for n, m in fix.items()}
 
                 reverse = {m: n for n, m in mapping.items()}
                 for m in self.products:

--- a/CGRtools/algorithms/standardize.py
+++ b/CGRtools/algorithms/standardize.py
@@ -1329,8 +1329,7 @@ class StandardizeReaction:
             for mapping in bad_query.get_mapping(cgr, automorphism_filter=False):
                 if not seen.isdisjoint(mapping.values()):  # prevent matching same RC
                     continue
-                mapping = {key : mapping.get(value, value) for key, value in fix.items()}
-                mapping.update(fix)
+                mapping = {key : value for key, value in fix.items()}
 
                 reverse = {m: n for n, m in mapping.items()}
                 for m in self.products:
@@ -1364,6 +1363,7 @@ class StandardizeReaction:
 
             gc = (~good).augmented_substructure((~good).center_atoms, deep=1)
             bc = (~bad).augmented_substructure((~bad).center_atoms, deep=1)
+            cgr_good, cgr_bad = ~good, ~bad
 
             atoms = set(bc.atoms_numbers + gc.atoms_numbers)      
 
@@ -1376,8 +1376,8 @@ class StandardizeReaction:
             strange_atoms = pr_b.difference(pr_g)
             atoms.update(strange_atoms)
 
-            bad_query = (~bad).substructure(atoms, as_query=True)
-            good_query = (~good).substructure(atoms.intersection(pr_g), as_query=True)
+            bad_query = (cgr_bad).substructure(atoms.intersection(cgr_bad), as_query=True)
+            good_query = (cgr_good).substructure(atoms.intersection(cgr_good), as_query=True)
 
             fix = {}
             rules = []

--- a/CGRtools/algorithms/standardize.py
+++ b/CGRtools/algorithms/standardize.py
@@ -1354,7 +1354,7 @@ class StandardizeReaction:
     def load_remapping_rules(cls, reactions):
         """
         Load AAM fixing rules. Required pairs of bad mapped and good mapped reactions.
-        Reactants in pairs should be fully equal (equal molecules and equal atom numbers).
+        Reactants in pairs should be fully equal (equal molecules and equal atom orders).
         Products should be equal but with different atom numbers.
         """
         for bad, good in reactions:
@@ -1362,8 +1362,8 @@ class StandardizeReaction:
                 raise ValueError('bad and good reaction should be equal')
             
             cgr_good, cgr_bad = ~good, ~bad
-            gc = (cgr_good).augmented_substructure((cgr_good).center_atoms, deep=1)
-            bc = (cgr_bad).augmented_substructure((cgr_bad).center_atoms, deep=1)
+            gc = (cgr_good).augmented_substructure([x for l in good.centers_list for x in l], deep=1)
+            bc = (cgr_bad).augmented_substructure([x for l in bad.centers_list for x in l], deep=1)
             
             atoms = set(bc.atoms_numbers + gc.atoms_numbers)      
 
@@ -1382,10 +1382,7 @@ class StandardizeReaction:
             fix = {}
             rules = []
             for mb, mg in zip(bad.products, good.products):
-                fx = min((m for m in
-                         ({k: v for k, v in m.items() if k != v}
-                          for m in mb.get_mapping(mg, automorphism_filter=False, optimize=False))
-                         if atoms.issuperset(m)), key=len)
+                fx = {k: v for k, v in zip(mb, mg) if k != v}
                 fix.update(fx)
             valid = set(fix).difference(strange_atoms)
             rules.append((bad_query, good_query, fix, valid))


### PR DESCRIPTION
Устранились ошибки связанные с созданием  bad_query. Итого, из 551 неправильных реакций : 35 с ошибкой создания рула( 34 из-за первого окружения + 1 из-за remap) , 21 реакцию fix_mapping не исправляет (так как в р.ц несколько компонентов)